### PR TITLE
C2C-142: Traefik to expose MinIO and Superset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The services have been split into multiple files this allows you to start only t
 
 ### Streaming and flatening pipelines only (without Superset)
 
-In cases where you don't need to start Superset (for example when you will use the Parquet export  job to create Parquet files to later upload onto Minio or S3, or if you want to plug your own BI tool) you can start only the streaming and flatening data pipelines by running:
+In cases where you don't need to start Superset (for example when you will use the Parquet export job to create Parquet files to later upload onto Minio or S3, or if you want to plug your own BI tool) you can start only the streaming and flatening data pipelines by running:
 
 `docker compose -f docker-compose-db.yaml -f docker-compose-data-pipelines.yaml up -d --build`
 


### PR DESCRIPTION
### Ticket
https://mekomsolutions.atlassian.net/browse/C2C-142

### What this PR brings
Enabling the project to be behind Traefik.
Making sure that Ozone Analytics can optionally be run on a different host than the system generating the data - making it fully a separate service.