### PR TITLE
C2C-223: Add docs as part of the published package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,5 @@ docker/data/parquet/
 !docker/sqls/mysql/.gitkeep
 !docker/sqls/postgres_restore/.gitkeep
 !docker/data/parquet/.gitkeep
+data/
+debezium-connect/

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version>3.3.0</version>
         <executions>
           <execution>
-            <id>copy-resources</id>
+            <id>Copy Docker resources</id>
             <phase>package</phase>
             <goals>
               <goal>copy-resources</goal>
@@ -40,6 +40,39 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+          <id>Copy README.md</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/</directory>
+                  <includes>
+                  <include>README.md</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>Copy readme/ folder</id>
+              <phase>package</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/readme</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>${project.basedir}/readme</directory>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
         </executions>
       </plugin>
       <!-- Packaging the project as a installable/deployable file -->


### PR DESCRIPTION
As part of the deploying Ozone Analytics at C2C, it would be important that the documentation is part of the final package, so that pulling it would bring all necessary files to run the project.

Ideally, this should probably be implemented as a separate classifier.