### PR TITLE
Add the time TimestampConverter to debezium-connector-postgres

### DIFF
--- a/docker/docker-compose-streaming-common.yaml
+++ b/docker/docker-compose-streaming-common.yaml
@@ -68,6 +68,7 @@ services:
       - 8383:8083
     volumes:
       - ./debezium-connect/jars/TimestampConverter-1.2.4-SNAPSHOT.jar:/kafka/connect/debezium-connector-mysql/TimestampConverter-1.2.4-SNAPSHOT.jar
+      - ./debezium-connect/jars/TimestampConverter-1.2.4-SNAPSHOT.jar:/kafka/connect/debezium-connector-postgres/TimestampConverter-1.2.4-SNAPSHOT.jar
     environment:
       - BOOTSTRAP_SERVERS=kafka:9092
       - GROUP_ID=1


### PR DESCRIPTION
Adds the TimestampConverter class to debezium-connector-postgres since it is used in the Kafka connect Postgres setup. Without it we get the error

```
ostgresConnectorConfig]
2024-03-08 05:23:43,733 WARN   ||  Configuration property 'toasted.value.placeholder' is deprecated and will be removed in future versions. Please use 'unavailable.value.placeholder' instead.   [io.debezium.connector.postgresql.PostgresConnectorConfig]
2024-03-08 05:23:43,735 ERROR  ||  Uncaught exception in REST call to /connectors/odoo-connector/config/   [org.apache.kafka.connect.runtime.rest.errors.ConnectExceptionMapper]
java.lang.IllegalArgumentException: Unable to find class oryanmoshe.kafka.connect.util.TimestampConverter
	at io.debezium.config.Instantiator.getInstanceWithProvidedConstructorType(Instantiator.java:55)
	at io.debezium.config.Instantiator.getInstance(Instantiator.java:28)
	at io.debezium.config.Configuration.getInstance(Configuration.java:1458)
	at io.debezium.config.Configuration.getInstance(Configuration.java:1444)
	at io.debezium.config.CommonConnectorConfig.lambda$getCustomConverters$1(CommonConnectorConfig.java:767)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at io.debezium.config.CommonConnectorConfig.getCustomConverters(CommonConnectorConfig.java:771)
	at io.debezium.config.CommonConnectorConfig.<init>(CommonConnectorConfig.java:631)
	at io.debezium.relational.RelationalDatabaseConnectorConfig.<init>(RelationalDatabaseConnectorConfig.java:629)
	at io.debezium.connector.postgresql.PostgresConnectorConfig.<init>(PostgresConnectorConfig.java:1103)
	at io.debezium.connector.postgresql.PostgresConnector.validateConnection(PostgresConnector.java:84)
	at io.debezium.connector.common.RelationalBaseSourceConnector.validate(RelationalBaseSourceConnector.java:54)
	at org.apache.kafka.connect.runtime.AbstractHerder.validateConnectorConfig(AbstractHerder.java:471)
	at org.apache.kafka.connect.runtime.AbstractHerder.lambda$validateConnectorConfig$2(AbstractHerder.java:367)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: oryanmoshe.kafka.connect.util.TimestampConverter
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at org.apache.kafka.connect.runtime.isolation.PluginClassLoader.loadClass(PluginClassLoader.java:103)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at io.debezium.config.Instantiator.getInstanceWithProvidedConstructorType(Instantiator.java:50)
	... 24 more
2024-03-08 05:24:17,610 INFO   ||  [Worker clientId=connect-1, groupId=1] Session key updated   [org.apache.kafka.connect.runtime.distributed.DistributedHerder]
^C

```