### PR TITLE
C2C-223: Add setting to show verbose errors

### DIFF
--- a/docker/drill/drill-override.conf
+++ b/docker/drill/drill-override.conf
@@ -1,4 +1,5 @@
 drill.exec.options: {
   sys.store.provider.local.path: "/data"
   store.parquet.reader.int96_as_timestamp:true
+  drill.exec.http.rest.errors.verbose: true
 }


### PR DESCRIPTION
Adds `drill.exec.http.rest.errors.verbose: true` to show more information when queries fail in Drill. This is part of the work done for https://mekomsolutions.atlassian.net/browse/C2C-223