### PR TITLE
OZ-551: Open Flink metrics port

### DIFF
--- a/docker/docker-compose-streaming-common.yaml
+++ b/docker/docker-compose-streaming-common.yaml
@@ -117,6 +117,7 @@ services:
     image: mekomsolutions/ozone-flink-jobs
     ports:
       - "8084:8081"
+      - "9250:9250"
     depends_on:
        odoo-replica-identity-migration:
          condition: service_completed_successfully


### PR DESCRIPTION
This PR opens port [9250](https://github.com/ozone-his/ozone-flink-jobs/blob/ba47877ed0618929109a687aa9b2a964c9adbd91/src/main/java/com/ozonehis/data/pipelines/utils/Environment.java#L95) as part of the ticket https://mekomsolutions.atlassian.net/browse/OZ-551