### PR TITLE
HSC-248: Add support for changing superset port when not using Traefik

### DIFF
--- a/docker/docker-compose-superset-ports.yaml
+++ b/docker/docker-compose-superset-ports.yaml
@@ -1,4 +1,4 @@
 services:
   superset:
     ports:
-      - "8088:8088"
+      - "${SUPERSET_PORT:-8888}:8088"


### PR DESCRIPTION
This addresses a port conflict issue when Analytics is deployed together with OpenMRS with Metrics enabled.